### PR TITLE
[Feat] 회원가입&로그인 로직 82

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import "./star.scss";
 import { Noto_Sans_KR } from "next/font/google";
 import { Providers } from "../components/providers";
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,14 @@
+"use client";
+import { accessTokenAtom } from "@/store/store";
+import { useAtom } from "jotai";
+import { useRouter } from "next/navigation";
+
 export default function Home() {
-  return <div>h2</div>;
+  const router = useRouter();
+  const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
+  if (accessToken) {
+    router.replace("/world");
+  } else {
+    router.replace("/users/register");
+  }
 }

--- a/src/app/star.scss
+++ b/src/app/star.scss
@@ -1,0 +1,236 @@
+$purple1: #181743;
+$purple2: #730f8e;
+$purple-pink: #a21190;
+$pink: #ea3281;
+$purple-pink1: #ce0682;
+$blue: #6e81e3;
+$light-pink: #eb6db4;
+$fuscia: #f9026d;
+$meteor-yellow: #fedc01;
+
+@mixin keyframes($animationName) {
+  @-webkit-keyframes #{$animationName} {
+    @content;
+  }
+  @-moz-keyframes #{$animationName} {
+    @content;
+  }
+  @-ms-keyframes #{$animationName} {
+    @content;
+  }
+  @keyframes #{$animationName} {
+    @content;
+  }
+}
+
+.stars-container {
+  position: absolute;
+  width: 100%;
+  height: 80%;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  .stars {
+    width: 170px;
+    top: 140px;
+    position: relative;
+    left: 220px;
+    div:nth-child(1) {
+      width: 20px;
+      position: relative;
+      height: 6px;
+      border-radius: 100%;
+      background: #fff;
+      animation: twinkle-width 1s ease infinite;
+    }
+    div:nth-child(2) {
+      width: 6px;
+      height: 20px;
+      top: -5px;
+      position: absolute;
+      background: #fff;
+      border-radius: 100%;
+      left: 7px;
+      top: -7px;
+      transform-origin: middle;
+      animation: twinkle-height 1s ease infinite;
+    }
+
+    div:nth-child(3) {
+      background: #fff;
+      content: "";
+      position: absolute;
+      width: 10px;
+      height: 10px;
+      left: 5px;
+      top: -2px;
+      border-radius: 100px;
+    }
+  }
+
+  .stars:nth-child(1) {
+    position: relative;
+    transform: scale(1);
+    top: -10px;
+    left: 10px;
+    div {
+      animation-delay: 0.8s;
+    }
+  }
+  .stars:nth-child(2) {
+    position: relative;
+    transform: scale(1.2);
+    top: 30px;
+    left: 40px;
+    div {
+      animation-delay: 0.5s;
+    }
+  }
+  .stars:nth-child(3) {
+    position: relative;
+    transform: scale(0.6);
+    bottom: 120px;
+    right: 10px;
+    div {
+      animation-delay: 0.5s;
+    }
+  }
+  .stars:nth-child(4) {
+    position: relative;
+    transform: scale(0.5);
+    top: -70px;
+    left: 350px;
+    div {
+      animation-delay: 0.8s;
+    }
+  }
+  .stars:nth-child(5) {
+    position: relative;
+    transform: scale(0.8);
+    top: 60px;
+    left: 80px;
+    div {
+      animation-delay: 0.5s;
+    }
+  }
+  .stars:nth-child(6) {
+    position: relative;
+    transform: scale(0.6);
+    bottom: -20px;
+    left: 150px;
+    div {
+      animation-delay: 0.5s;
+    }
+  }
+  .stars:nth-child(7) {
+    position: relative;
+    transform: scale(0.8);
+    top: -60px;
+    left: 390px;
+    div {
+      animation-delay: 0.6s;
+    }
+  }
+  .stars:nth-child(8) {
+    position: relative;
+    transform: scale(1.1);
+    top: 16px;
+    left: 370px;
+    div {
+      animation-delay: 0.5s;
+    }
+  }
+  .stars:nth-child(9) {
+    position: relative;
+    transform: scale(0.6);
+    top: 20px;
+    left: 150px;
+    div {
+      animation-delay: 0.5s;
+    }
+  }
+  .stars:nth-child(10) {
+    position: relative;
+    transform: scale(0.5);
+    bottom: -50px;
+    left: 350px;
+    div {
+      animation-delay: 0.8s;
+    }
+  }
+  .stars-2 {
+    border-radius: 100%;
+    position: absolute;
+    animation: twinkle 0.5s ease infinite;
+  }
+  .stars-2:nth-child(5) {
+    width: 10px;
+    height: 10px;
+    background: linear-gradient(to right, $purple2, transparent);
+    left: 150px;
+    top: 120px;
+    animation-delay: 0.2s;
+  }
+
+  .stars-2:nth-child(6) {
+    width: 10px;
+    height: 10px;
+    background: linear-gradient(to right, transparent, $pink);
+    left: 420px;
+    top: -50px;
+  }
+  .stars-2:nth-child(7) {
+    width: 8px;
+    height: 8px;
+    background: linear-gradient(to right, transparent, $purple2);
+    left: 350px;
+    top: -70px;
+    animation-delay: 0.8s;
+    animation-duration: 1s;
+  }
+}
+
+/* twinkle-height 애니메이션 */
+@keyframes twinkle-height {
+  0% {
+    height: 20px;
+    top: -7px;
+  }
+  50% {
+    height: 10px;
+    top: -3px;
+  }
+  100% {
+    height: 20px;
+    top: -7px;
+  }
+}
+
+/* twinkle-width 애니메이션 */
+@keyframes twinkle-width {
+  0% {
+    width: 20px;
+    left: 0px;
+  }
+  50% {
+    width: 10px;
+    left: 5px;
+  }
+  100% {
+    width: 20px;
+    left: 0px;
+  }
+}
+
+/* twinkle 애니메이션 */
+@keyframes twinkle {
+  0% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}

--- a/src/app/users/layout.tsx
+++ b/src/app/users/layout.tsx
@@ -1,3 +1,4 @@
+import CommonLayout from "@/components/ui/CommonLayout";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -11,8 +12,11 @@ export default function UsersLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="w-screen max-w-xl h-screen bg-[url('/images/bg.jpg')] flex flex-col items-center justify-center p-6 space-y-6 font-ptr">
+    // <div className="w-screen max-w-xl h-screen bg-[url('/images/bg.jpg')] flex flex-col items-center justify-center p-6 space-y-6 font-ptr">
+    <CommonLayout useButton={false}>
+      <img src="/images/logo-160x160.png" alt="로고" className="m-auto mb-4" />
       {children}
-    </div>
+    </CommonLayout>
+    // </div>
   );
 }

--- a/src/app/users/login/page.tsx
+++ b/src/app/users/login/page.tsx
@@ -39,7 +39,6 @@ export default function Login() {
 
   return (
     <>
-      <img src="/images/logo-160x160.png" alt="로고" />
       <form onSubmit={onSubmit} className="grid w-full">
         <div className="bg-white/40 rounded-lg px-2 py-4 space-y-4">
           <div>
@@ -69,12 +68,30 @@ export default function Login() {
             <p className={errorCSS}>{errors?.password?.message}</p>
           </div>
         </div>
-        <div className="w-32 justify-self-center mt-4">
-          <Button
-            text="로그인"
-            onClick={onSubmit}
-            disabled={!isDirty || !isValid}
-          />
+        <div className="justify-self-center mt-4">
+          <div className="w-32 m-auto ">
+            <Button
+              text="로그인"
+              onClick={onSubmit}
+              disabled={!isDirty || !isValid}
+            />
+          </div>
+
+          <p className="font-sm text-stock-dark-800 mt-4">
+            아직{" "}
+            <span className="font-bold text-stock-purple-79 font-ptb">
+              Stockmon World
+            </span>
+            를 사용하고 있지 않으신가요?{"  "}
+            <span
+              className="font-bold cursor-pointer"
+              onClick={() => {
+                router.push("/users/register");
+              }}
+            >
+              회원가입
+            </span>
+          </p>
         </div>
       </form>
     </>

--- a/src/app/users/login/page.tsx
+++ b/src/app/users/login/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Button from "@/components/ui/Button";
+import Modal from "@/components/ui/Modal";
 import { useAuth } from "@/hooks/useAuth";
 import { useRouter } from "next/navigation";
 import * as React from "react";
@@ -9,6 +10,12 @@ type FormData = {
   nickname: string;
   password: string;
 };
+interface IModal {
+  isOpen: boolean;
+  content: string;
+  title?: string;
+  onClick: () => void;
+}
 
 export default function Login() {
   const {
@@ -17,19 +24,42 @@ export default function Login() {
     watch,
     formState: { errors, isDirty, isValid },
     getValues,
+    reset,
   } = useForm<FormData>();
   const router = useRouter();
   const { signIn } = useAuth();
+  const [modal, setModal] = React.useState<IModal>({
+    isOpen: false,
+    content: "",
+    title: "",
+    onClick: () => {},
+  });
 
-  const onSubmit = handleSubmit(async (data) => {
-    const res = await signIn({
-      nickname: data.nickname,
-      password: data.password,
+  const closeModal = () => {
+    setModal({
+      isOpen: false,
+      content: "",
+      onClick: () => {},
     });
-    console.log("signIn res: ", res);
-    if (res) {
-      console.log(res, "님. 환영합니다!");
-      router.push("/world");
+  };
+  const onSubmit = handleSubmit(async (data) => {
+    try {
+      const res = await signIn({
+        nickname: data.nickname,
+        password: data.password,
+      });
+      if (res) {
+        router.push("/world");
+      }
+    } catch (error: any) {
+      console.log("error fail login");
+      setModal({
+        isOpen: true,
+        title: "로그인 실패",
+        content: error.toString(),
+        onClick: closeModal,
+      });
+      reset();
     }
   });
 
@@ -94,6 +124,12 @@ export default function Login() {
           </p>
         </div>
       </form>
+      <Modal
+        open={modal.isOpen}
+        onClose={modal.onClick}
+        title={modal.title}
+        describe={modal.content}
+      />
     </>
   );
 }

--- a/src/app/users/register/page.tsx
+++ b/src/app/users/register/page.tsx
@@ -41,7 +41,6 @@ export default function Register() {
 
   return (
     <>
-      <img src="/images/logo-160x160.png" alt="로고" />
       <form onSubmit={onSubmit} className="grid w-full">
         <div className="bg-white/40 rounded-lg px-2 py-4 space-y-4">
           <div>
@@ -102,12 +101,25 @@ export default function Register() {
             />
           </div>
         </div>
-        <div className="w-32 justify-self-center mt-4">
-          <Button
-            text="회원가입"
-            onClick={onSubmit}
-            disabled={!isDirty || !isValid}
-          />
+        <div className=" justify-self-center mt-4">
+          <div className="w-32 m-auto ">
+            <Button
+              text="회원가입"
+              onClick={onSubmit}
+              disabled={!isDirty || !isValid}
+            />
+          </div>
+          <p className="font-sm text-stock-dark-800 mt-4">
+            이미 회원이신가요?{" "}
+            <span
+              className="font-bold cursor-pointer"
+              onClick={() => {
+                router.push("/users/login");
+              }}
+            >
+              로그인
+            </span>
+          </p>
         </div>
       </form>
     </>

--- a/src/components/ui/CommonLayout.tsx
+++ b/src/components/ui/CommonLayout.tsx
@@ -1,12 +1,19 @@
 import React from "react";
 import BtnClose from "./BtnClose";
+import Twinkle from "./Twinkle";
 
 type Props = {
   header?: React.ReactNode;
   children: React.ReactNode;
   title?: string;
+  useButton?: boolean;
 };
-export default function CommonLayout({ children, header, title }: Props) {
+export default function CommonLayout({
+  children,
+  header,
+  title,
+  useButton = true,
+}: Props) {
   return (
     <div className="w-full h-full overflow-x-hidden overflow-y-scroll">
       <div className="fixed w-full h-full overflow-hidden z-0">
@@ -14,6 +21,7 @@ export default function CommonLayout({ children, header, title }: Props) {
           className="bg-cover bg-center w-full h-full fixed z-[-1]"
           style={{ backgroundImage: "url('/images/bg.jpg')" }}
         ></div>
+        <Twinkle />
       </div>
       <div className="p-6 max-w-xl w-xl h-screen relative z-1 m-auto flex flex-col items-center justify-between gap-6">
         <header className="w-full">
@@ -23,9 +31,11 @@ export default function CommonLayout({ children, header, title }: Props) {
           {header}
         </header>
         <main className="flex-1 w-full h-full overflow-scroll">{children}</main>
-        <footer className="w-full flex justify-center">
-          <BtnClose />
-        </footer>
+        {useButton && (
+          <footer className="w-full flex justify-center">
+            <BtnClose />
+          </footer>
+        )}
       </div>
     </div>
   );

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -31,14 +31,18 @@ export default function Modal({
         onClick={onClose}
       >
         <div
-          className="flex flex-col gap-4 justify-center items-center bg-somsatang-gradient p-4 w-full rounded-lg"
+          className="flex flex-col gap-4 max-w-xl justify-center items-center bg-somsatang-gradient p-4 w-full rounded-lg"
           onClick={(e) => e.stopPropagation()}
         >
           <header className="w-full p-3 flex flex-col gap-2 text-center text-stock-blue-950 bg-white rounded-lg break-all">
             {title && <h2 className="font-ptb text-lg">{title}</h2>}
-            {describe && <p className="font-ptr text-sm w-full break-all">{describe}</p>}
+            {describe && (
+              <p className="font-ptr text-sm w-full break-all">{describe}</p>
+            )}
           </header>
-          {isLoading && <AiOutlineLoading className="animate-spin m-auto" color={"white"} />}
+          {isLoading && (
+            <AiOutlineLoading className="animate-spin m-auto" color={"white"} />
+          )}
           {!isLoading && children}
           <footer className="flex justify-center gap-16">
             {hasClose && (

--- a/src/components/ui/Twinkle.tsx
+++ b/src/components/ui/Twinkle.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+
+export default function Twinkle() {
+  return (
+    <div className="stars-container z-0">
+      <div className="stars">
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+      <div className="stars">
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+      <div className="stars">
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+      <div className="stars">
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+      <div className="stars">
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+      <div className="stars">
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+      <div className="stars">
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+      <div className="stars">
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+      <div className="stars">
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -17,13 +17,13 @@ export function useAuth() {
         password,
         inviterNickname,
       });
-      if (res && res.data) {
+      const loginRes = await signIn({ nickname, password });
+      if (res && res.data && loginRes) {
         return res.data.nickname;
       }
     } catch (error) {
       if (axios.isAxiosError(error)) {
-        console.log("error:", error);
-        throw Error(error.message);
+        throw Error(error.response?.data.message);
       }
     }
   }
@@ -41,7 +41,9 @@ export function useAuth() {
       }
     } catch (error) {
       //TODO: 에러 메세지 전달
-      throw Error("");
+      if (axios.isAxiosError(error)) {
+        throw Error(error.response?.data.message);
+      }
     }
   }
 


### PR DESCRIPTION
## 변경 사항 요약
> 요약 내용 나열 + (이미지)
- [ ] 모달 최대너비 적용 
- [ ] 로그인&회원가입 실패&성공 모달 추가
<img width="655" alt="Screenshot 2024-09-05 at 13 25 13" src="https://github.com/user-attachments/assets/3db1fc39-be4f-4431-aa84-e7d933addf98">
- [ ] 로그인&회원가입시 월드로이동
- [ ] 로그인&회원가입 필드 누락 혹은 틀릴시 에러 메세지 노출 
<img width="565" alt="Screenshot 2024-09-05 at 13 25 41" src="https://github.com/user-attachments/assets/0f183a9c-9145-4ea0-8254-e8297c75ae02">
- [ ] 루트페이지 접근시 로그인여부에따라 월드 혹은 회원가입페이지로이동
- [ ] 배경 별 효과 추가(아직 위치못잡음)
<img width="650" alt="Screenshot 2024-09-05 at 13 26 19" src="https://github.com/user-attachments/assets/2ebab62d-dd3d-4e57-b2ef-b6ad5bea5588">


## 이슈 번호
- close #82
