### PR TITLE
[Feat] 스톡몬 계란판 페이지 API 연동 #83

### DIFF
--- a/src/apis/stockBookAPI.ts
+++ b/src/apis/stockBookAPI.ts
@@ -4,6 +4,7 @@ import {
   IStockmonsRes,
 } from "@/types/stockmons";
 import { BaseApi, handleApiError } from "./baseAPI";
+import { SuccessResponse } from "@/types/SuccessResponse";
 
 export default class stockBookAPI extends BaseApi {
   // 스톡몬 목록 조회 API
@@ -20,11 +21,9 @@ export default class stockBookAPI extends BaseApi {
   async getStockmonDetail(id: string): Promise<IStockmonDetailRes | null> {
     try {
       const response = await this.fetcher.get(`/api/core/stockmons/${id}`);
-
       if (response.data.result === "fail") {
         return null;
       }
-
       return response.data.data;
     } catch (error) {
       handleApiError(error);
@@ -37,6 +36,18 @@ export default class stockBookAPI extends BaseApi {
       const response = await this.fetcher.get(`/api/core/stockmons/${id}`);
 
       return response.data.data;
+    } catch (error) {
+      handleApiError(error);
+    }
+  }
+
+  // 스톡몬 실제 주신 받기 API
+  async postStockExchange(stockCode: string): Promise<SuccessResponse<null>> {
+    try {
+      const response = await this.fetcher.post(`/api/core/stocks/exchange`, {
+        stockCode: stockCode,
+      });
+      return new SuccessResponse(response.status, "주식 받기 성공", null);
     } catch (error) {
       handleApiError(error);
     }

--- a/src/app/books/[id]/collection/page.tsx
+++ b/src/app/books/[id]/collection/page.tsx
@@ -87,7 +87,7 @@ export default function Collection() {
             index < stockmonData.catchCount ? (
               <img
                 key={index}
-                src={stockmonData.imageUrl}
+                src={`${process.env.NEXT_PUBLIC_S3_URL}/${stockmonData.stockmonId}.png`}
                 alt={stockmonData.stockmonName}
                 className="aspect-square object-cover bg-white rounded-lg"
               />

--- a/src/app/books/[id]/collection/page.tsx
+++ b/src/app/books/[id]/collection/page.tsx
@@ -8,29 +8,10 @@ import { COLLECTION_MAX } from "@/types/stockmons";
 import Button from "@/components/ui/Button";
 import Modal from "@/components/ui/Modal";
 import RealStockExchangeModal from "@/components/ui/books/RealStockExchangeModal";
-import data from "@/../dummy/books/bookDetail.json";
 import NewPoint from "@/components/ui/NewPoint";
 import { useStockBook } from "@/hooks/useStockBook";
-
-const fetcher = (url: string) => {
-  //TODO: 스톡몬 개별 페이지 조회 api 연결
-  return data;
-};
-
-const fetcher2 = (url: string): Promise<ProfileType> => {
-  // TODO: 스톡몬 개별 페이지 조회 api 연결
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({
-        hasAccount: true,
-      });
-    }, 1000);
-  });
-};
-
-type ProfileType = {
-  hasAccount: boolean;
-};
+import memberAPI from "@/apis/memberAPI";
+import { IAccountInfoRes } from "@/types/member";
 
 export default function Collection() {
   const router = useRouter();
@@ -40,6 +21,7 @@ export default function Collection() {
     params.id,
     getStockmonDetail
   );
+  const service = new memberAPI();
   const [accountModalOpen, setAccountModalOpen] = useState(false);
   const [getStockModalOpen, setGetStockModalOpen] = useState(false);
   const [buttonLoading, setButtonLoading] = useState(false);
@@ -49,11 +31,16 @@ export default function Collection() {
     return <Loading />;
   }
 
+  if (stockmonData) {
+    stockmonData.catchCount = 20;
+  }
+
   const handleExchange = async () => {
     setButtonLoading(true);
-    const profileData: ProfileType = await fetcher2(`/api/core/users/account`);
+    const profileData: IAccountInfoRes | null =
+      await service.getAccountStatus();
     setButtonLoading(false);
-    if (profileData.hasAccount) {
+    if (profileData?.hasAccount) {
       setGetStockModalOpen(true);
     } else {
       setAccountModalOpen(true);

--- a/src/app/books/[id]/collection/page.tsx
+++ b/src/app/books/[id]/collection/page.tsx
@@ -10,6 +10,7 @@ import Modal from "@/components/ui/Modal";
 import RealStockExchangeModal from "@/components/ui/books/RealStockExchangeModal";
 import data from "@/../dummy/books/bookDetail.json";
 import NewPoint from "@/components/ui/NewPoint";
+import { useStockBook } from "@/hooks/useStockBook";
 
 const fetcher = (url: string) => {
   //TODO: 스톡몬 개별 페이지 조회 api 연결
@@ -34,9 +35,10 @@ type ProfileType = {
 export default function Collection() {
   const router = useRouter();
   const params = useParams();
+  const { getStockmonDetail } = useStockBook();
   const { data: stockmonData, error: stockmonError } = useSWR(
-    `/api/stockmons/${params.id}`,
-    fetcher
+    params.id,
+    getStockmonDetail
   );
   const [accountModalOpen, setAccountModalOpen] = useState(false);
   const [getStockModalOpen, setGetStockModalOpen] = useState(false);

--- a/src/app/books/[id]/collection/page.tsx
+++ b/src/app/books/[id]/collection/page.tsx
@@ -51,7 +51,7 @@ export default function Collection() {
       setGetStockModalOpen(true);
     } catch (err) {
       alert("계좌 개설 중 에러가 발생하였습니다.");
-      window.location.reload();
+      setAccountModalOpen(false);
     }
   };
 
@@ -63,7 +63,7 @@ export default function Collection() {
       router.refresh();
     } catch (err) {
       alert("주식 받기 중 에러가 발생하였습니다.");
-      window.location.reload();
+      setGetStockModalOpen(false);
     }
   };
 

--- a/src/components/ui/books/StockmonCard.tsx
+++ b/src/components/ui/books/StockmonCard.tsx
@@ -33,7 +33,7 @@ export default function StockmonCard({ data }: Props) {
         <p className="text-stock-dark-300">No.{data.stockCode}</p>
         <img
           className={`w-2/3 mx-auto ${animate ? "gelatine" : ""}`}
-          src={data.imageUrl}
+          src={`${process.env.NEXT_PUBLIC_S3_URL}/${data.stockmonId}.png`}
           alt={data.stockmonName}
           onClick={handleImgClick}
         />

--- a/src/components/ui/books/StockmonItem.tsx
+++ b/src/components/ui/books/StockmonItem.tsx
@@ -20,7 +20,10 @@ export default function StockmonItem({ stockmon }: Props) {
       {stockmon ? (
         <div className="relative ">
           {stockmon.catchCount >= COLLECTION_MAX && <NewPoint />}
-          <img className="w-full bg-white" src="/images/octopus.png" />
+          <img
+            className="w-full bg-white"
+            src={`${process.env.NEXT_PUBLIC_S3_URL}/${stockmon.id}.png`}
+          />
           <p className="p-2 text-center text-white font-ptr">{stockmon.name}</p>
         </div>
       ) : (

--- a/src/hooks/useStockBook.ts
+++ b/src/hooks/useStockBook.ts
@@ -19,8 +19,16 @@ export function useStockBook() {
   );
 
   const getStockmonChart = useCallback(
-    async (code: string) => {
-      const res = await service.getStockmonChart(code);
+    async (stockCode: string) => {
+      const res = await service.getStockmonChart(stockCode);
+      return res;
+    },
+    [service]
+  );
+
+  const postStockExchange = useCallback(
+    async (stockCode: string) => {
+      const res = await service.postStockExchange(stockCode);
       return res;
     },
     [service]
@@ -30,5 +38,6 @@ export function useStockBook() {
     getStockmons,
     getStockmonDetail,
     getStockmonChart,
+    postStockExchange,
   };
 }


### PR DESCRIPTION
ex) [Feat] PR명 #00 (제목 작성후 지워주세요!)
## 변경 사항 요약
> 계란판 페이지에 필요한 API 연동
> - 잡은 스톡몬 수, 계좌 개설 여부 및 개설 요청, 실제 주식 받기 API 연동
- [x] 잡은 스톡몬 수 API

![image](https://github.com/user-attachments/assets/812a8249-1b99-4a92-8e73-acf8fe6732dc)

- [x] 계좌 개설 여부 및 개설 요청 API

![image](https://github.com/user-attachments/assets/347caa4f-b488-4f6c-9d21-1447e5b1e65a)


- [x] 실제 주식 받기 API

![image](https://github.com/user-attachments/assets/05996153-8704-4f35-b2e2-2ea3cb72ce37)



## 이슈 번호
- close #83
